### PR TITLE
Missing combinator in `#buttons .lotsofcontent` #2

### DIFF
--- a/app/vocabs/css.vocab/sample.haml
+++ b/app/vocabs/css.vocab/sample.haml
@@ -153,7 +153,7 @@
 %span.statement.rule-set<>
   %span.selector<>
     %span.simple-selector.id-selector<> #buttons
-    &nbsp;
+    %span.combinator.descendant-combinator<> &nbsp;
     %span.simple-selector.class-selector<> .lotsofcontent
   %span<> ,<br>
   %span.selector<>


### PR DESCRIPTION
Whitespace character between simple selectors if a descendant combinator.